### PR TITLE
Clarify the priority of ALPN and fix possible flaw

### DIFF
--- a/draft-ietf-radext-radiusv11.md
+++ b/draft-ietf-radext-radiusv11.md
@@ -314,9 +314,9 @@ Values
 >>
 >>> If the server receives no ALPN name from the client, it MUST use historic RADIUS/TLS.
 >>>
->>> If the server receives only one ALPN name which matches "radius/1.0" from the client, it MUST reply with ALPN "radius/1.0", and then use historic RADIUS/TLS.
+>>> If the server recieves one or more ALPN names from the client which include the ALPN name "radius/1.1", it MUST reply with ALPN "radius/1.1", and then use RADIUS/1.1.
 >>>
->>> If the server receives one or more ALPN names which include "radius/1.1" from the client, it MUST reply with ALPN "radius/1.1", and then use RADIUS/1.1
+>>> Else, if the server recieves one or more ALPN names from the client which include the ALPN name "radius/1.0" but not "radius/1.1", it MUST reply with ALPN "radius/1.0", and then use historic RADIUS/TLS.
 >>>
 >>> If the server receives one or more ALPN names from the client, but none of the names match "radius/1.0" or "radius/1.1", it MUST reply with a TLS alert of "no_application_protocol" (120), and then close the TLS connection.
 


### PR DESCRIPTION
The previous text is ambiguous and can be read in two different ways:

Option 1: if the server recieves ALPNs "radius/1.0" and "some-other-alpn-name" and you read "only one ALPN name which matches" as "there must be only one ALPN, and if that one matches", then this would force the server to abort the connection at this point.

Option 2: If you read "only one ALPN name which matches" as "there can be multiple ALPNs, but only one matching the string" then we have the problem of double-Spec if "radius/1.0" and "radius/1.1" was sent.

This new text makes the behavior explicit by first mentioning RADIUS/1.1 and then defining historic RADIUS/TLS as fall-back.